### PR TITLE
修改两处bug并增加一个新特性

### DIFF
--- a/src/components/common/button/index.jsx
+++ b/src/components/common/button/index.jsx
@@ -15,13 +15,7 @@ const Button = ({
   fontSize,
   disabled
 }) => {
-  const style =!disabled ? {
-    width: `${width}px`,
-    height: `${height}px`,
-    borderRadius: "4px",
-    backgroundColor: `${bgColor}`,
-    border: `${border}`
-  } : {
+  const style =disabled ? {
     width: `${width}px`,
     height: `${height}px`,
     borderRadius: "4px",
@@ -29,17 +23,23 @@ const Button = ({
     border: "1px solid",
     color: "rgba(0, 0, 0, 0.25)",
     "borderColor": "#d9d9d9"
+  } : {
+    width: `${width}px`,
+    height: `${height}px`,
+    borderRadius: "4px",
+    backgroundColor: `${bgColor}`,
+    border: `${border}`
   };
 
   const btText = {
-    color: !disabled ? `${textColor}` : "rgba(0, 0, 0, 0.25)",
+    color: disabled ? "rgba(0, 0, 0, 0.25)"  : `${textColor}`,
     fontSize: `${fontSize}px`
   };
   return (
     <div style={style}>
       <div
-        className={!disabled ? "bt" : "bt bt-disabled"}
-        onClick={!disabled ? onClick : null}
+        className={disabled ? "bt bt-disabled" : "bt"}
+        onClick={disabled ? ()=>{} : onClick}
         onKeyDown={() => {}}
         role="presentation"
       >
@@ -79,7 +79,7 @@ Button.defaultProps = {
   fontSize: "16",
   text: "Button",
   to: "",
-  onClick: null,
+  onClick: ()=>{},
   disabled: false
 };
 

--- a/src/components/common/button/index.jsx
+++ b/src/components/common/button/index.jsx
@@ -12,25 +12,34 @@ const Button = ({
   bgColor,
   textColor,
   border,
-  fontSize
+  fontSize,
+  disabled
 }) => {
-  const style = {
+  const style =!disabled ? {
     width: `${width}px`,
     height: `${height}px`,
     borderRadius: "4px",
     backgroundColor: `${bgColor}`,
     border: `${border}`
+  } : {
+    width: `${width}px`,
+    height: `${height}px`,
+    borderRadius: "4px",
+    backgroundColor: "#f5f5f5",
+    border: "1px solid",
+    color: "rgba(0, 0, 0, 0.25)",
+    "borderColor": "#d9d9d9"
   };
 
   const btText = {
-    color: `${textColor}`,
+    color: !disabled ? `${textColor}` : "rgba(0, 0, 0, 0.25)",
     fontSize: `${fontSize}px`
   };
   return (
     <div style={style}>
       <div
-        className="bt"
-        onClick={onClick}
+        className={!disabled ? "bt" : "bt bt-disabled"}
+        onClick={!disabled ? onClick : null}
         onKeyDown={() => {}}
         role="presentation"
       >
@@ -57,7 +66,8 @@ Button.propTypes = {
   text: PropTypes.string,
   fontSize: PropTypes.string,
   to: PropTypes.string,
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  disabled: PropTypes.bool
 };
 
 Button.defaultProps = {
@@ -69,7 +79,8 @@ Button.defaultProps = {
   fontSize: "16",
   text: "Button",
   to: "",
-  onClick: null
+  onClick: null,
+  disabled: false
 };
 
 export default Button;

--- a/src/components/common/button/index.scss
+++ b/src/components/common/button/index.scss
@@ -17,3 +17,7 @@
   transform: translateY(-50%);
   font-weight: 400;
 }
+
+.bt-disabled {
+  cursor: not-allowed
+}

--- a/src/components/common/button/readme.md
+++ b/src/components/common/button/readme.md
@@ -13,3 +13,4 @@ Button——按钮组件
 | fontSize | 文字大小 （默认为16px） | string |
 | to | 同Link标签的"to"属性 | string |
 | onClick | 点击事件 | Func |
+| disabled |按钮失效状态|bool|

--- a/src/components/common/header/inform/index.jsx
+++ b/src/components/common/header/inform/index.jsx
@@ -10,17 +10,13 @@ import MessageService from "service/message";
 import { Store } from "store";
 import "./index.scss";
 
-const kind = ["进度", "文件", "评论", "团队"];
+const kind = ["文档", "文件"];
 function getPath(sourcekind, projectID, sourceID) {
   switch (sourcekind) {
     case 0:
-      return `/status/${sourceID}`;
+      return `/project/${projectID}/doc/${sourceID}`;
     case 1:
       return `/project/${projectID}/file/${sourceID}`;
-    case 2:
-      return `/project/${projectID}/file/${sourceID}`;
-    case 3:
-      return `/project/${projectID}/doc/${sourceID}`;
     default:
       return `/`;
   }

--- a/src/modules/message/index.jsx
+++ b/src/modules/message/index.jsx
@@ -11,18 +11,14 @@ import MessageService from "service/message";
 import "static/css/common.scss";
 import "./index.scss";
 
-const kind = ["进度", "文件", "评论", "团队"];
+const kind = ["文档", "文件"];
 
 function getPath(sourcekind, projectID, sourceID) {
   switch (sourcekind) {
     case 0:
-      return `/status/${sourceID}`;
+      return `/project/${projectID}/doc/${sourceID}`;
     case 1:
       return `/project/${projectID}/file/${sourceID}`;
-    case 2:
-      return `/project/${projectID}/file/${sourceID}`;
-    case 3:
-      return `/project/${projectID}/doc/${sourceID}`;
     default:
       return `/`;
   }

--- a/src/modules/project/detail/filePreview/index.jsx
+++ b/src/modules/project/detail/filePreview/index.jsx
@@ -37,11 +37,13 @@ class DocPreview extends Component {
       // 评论列表
       commentList: [],
       // 发表评论的输入值
-      commentInput: ""
+      commentInput: "",
       // 评论当前页数
       // currentPage: 1,
       // 总页数
       // pageNums: 1
+      // 文档类型： 0表示直接新页面打开系列 1表示office系列
+      fileType: 0
     };
     this.getFileInfo = this.getFileInfo.bind(this);
     this.isFocus = this.isFocus.bind(this);
@@ -93,6 +95,7 @@ class DocPreview extends Component {
 
   // 请求该文件的详情信息
   getFileInfo() {
+    const officeDocs = ["doc", "docx", "xls", "xlsx", "ppt", "pptx"]
     const { id } = this.state;
     const postData = {
       folder: [],
@@ -104,9 +107,12 @@ class DocPreview extends Component {
         const regex = /\D/;
         const timeArr = res.FileList[0].create_time.split(regex);
         const timeStr = `${timeArr[0]}年${timeArr[1]}月${timeArr[2]}日`;
+        const DocName = /.*\.(\w+)/.exec(res.FileList[0].url)
+        let DocType = officeDocs.indexOf(DocName[1]) !== -1 ? 1 : 0
         this.setState({
           fileInfo: res.FileList[0],
           createTime: timeStr,
+          fileType: DocType,
           creator
         });
       })
@@ -256,7 +262,8 @@ class DocPreview extends Component {
       loading,
       // currentPage,
       // pageNums,
-      isFocus
+      isFocus,
+      fileType
     } = this.state;
     const { storeAvatar } = this.props;
 
@@ -317,14 +324,19 @@ class DocPreview extends Component {
                   {createTime}
                   上传
                 </div>
-                <a
-                  className="filePreview-onLine"
-                  href={fileInfo.url}
-                  target={fileInfo.url}
-                  rel="noopener noreferrer"
+                {fileType ? (<a
+                        className="filePreview-onLine"
+                        href={'https://view.officeapps.live.com/op/view.aspx?src='+ fileInfo.url}
+                        target={'https://view.officeapps.live.com/op/view.aspx?src=' + fileInfo.url}
+                    >
+                      在线预览
+                    </a>) : (<a
+                    className="filePreview-onLine"
+                    href={fileInfo.url}
+                    target={fileInfo.url}
                 >
                   在线预览
-                </a>
+                </a>)}
               </div>
             </div>
             {/* 头部右边 */}

--- a/src/modules/status/markdown/edit.jsx
+++ b/src/modules/status/markdown/edit.jsx
@@ -20,7 +20,9 @@ class edit extends Component {
       content: null,
       title: "",
       textnone: false,
-      modalVisible: false
+      modalVisible: false,
+      submitted: false,
+      submitText: "保存并提交"
     };
     this.draftId = `status-draft${props.match.params.id || ""}`;
     this.handleChange = this.handleChange.bind(this);
@@ -131,32 +133,37 @@ class edit extends Component {
       return;
     }
     if (match.path === "/edit") {
-      StatusService.addNewStatu(title, content).catch(error => {
-        Store.dispatch({
-          type: "substituteWrongInfo",
-          payload: error
-        });
-      });
-      // 清除草稿缓存
-      localStorage.removeItem(this.draftId);
-      window.history.back();
+      StatusService.addNewStatu(title, content)
+          .then(() => {
+            // 清除草稿缓存
+            localStorage.removeItem(this.draftId);
+            window.history.back();
+          })
+          .catch(error => {
+            Store.dispatch({
+              type: "substituteWrongInfo",
+              payload: error
+            })
+          })
     } else {
-      StatusService.changeStatu(match.params.id, title, content).catch(
-        error => {
-          Store.dispatch({
-            type: "substituteWrongInfo",
-            payload: error
-          });
-        }
-      );
-      // 清除草稿缓存
-      localStorage.removeItem(this.draftId);
-      window.history.back();
+      StatusService.changeStatu(match.params.id, title, content)
+          .then(() => {
+            // 清除草稿缓存
+            localStorage.removeItem(this.draftId);
+            window.history.back();
+          })
+          .catch(
+              error => {
+                Store.dispatch({
+                  type: "substituteWrongInfo",
+                  payload: error
+                });
+              });
     }
   }
 
   render() {
-    const { title, textnone, content, modalVisible } = this.state;
+    const { title, textnone, content, modalVisible, submitted, submitText } = this.state;
 
     return (
       <div className="subject edit-marginHeader">
@@ -177,9 +184,17 @@ class edit extends Component {
           <div className="status-save-bt">
             <Button
               onClick={() => {
-                this.save(title);
+                if(!submitted){
+                  this.save(title);
+                  this.setState({
+                    submitted: true,
+                    submitText : "正在提交.."
+                  })
+                } else {
+                  alert("请不要重复提交！")
+                }
               }}
-              text="保存并返回"
+              text={submitText}
             />
           </div>
         </div>

--- a/src/modules/status/markdown/edit.jsx
+++ b/src/modules/status/markdown/edit.jsx
@@ -22,7 +22,6 @@ class edit extends Component {
       textnone: false,
       modalVisible: false,
       submitted: false,
-      submitText: "保存并提交"
     };
     this.draftId = `status-draft${props.match.params.id || ""}`;
     this.handleChange = this.handleChange.bind(this);
@@ -125,13 +124,6 @@ class edit extends Component {
   save(title) {
     const { match } = this.props;
     const { content } = this.state;
-
-    if (title.trim() === "" || content.trim() === "") {
-      this.setState({
-        textnone: true
-      });
-      return;
-    }
     if (match.path === "/edit") {
       StatusService.addNewStatu(title, content)
           .then(() => {
@@ -163,7 +155,7 @@ class edit extends Component {
   }
 
   render() {
-    const { title, textnone, content, modalVisible, submitted, submitText } = this.state;
+    const { title, textnone, content, modalVisible, submitted } = this.state;
 
     return (
       <div className="subject edit-marginHeader">
@@ -183,18 +175,20 @@ class edit extends Component {
           )}
           <div className="status-save-bt">
             <Button
-              onClick={() => {
-                if(!submitted){
-                  this.save(title);
-                  this.setState({
-                    submitted: true,
-                    submitText : "正在提交.."
-                  })
-                } else {
-                  alert("请不要重复提交！")
-                }
-              }}
-              text={submitText}
+                onClick={() => {
+                  if (title.trim() === "" || content.trim() === "") {
+                    this.setState({
+                      textnone: true
+                    });
+                  } else {
+                    this.save(title);
+                    this.setState({
+                      submitted: true
+                    })
+                  }
+                }}
+                disabled={submitted}
+                text={submitted ? "提交中" : "保存并提交"}
             />
           </div>
         </div>


### PR DESCRIPTION
# 修正1: 改正通知跳转问题
# 修正2:改正通知重复提交问题
更正检测标题或内容为空逻辑，改为在点击时判断标题或内容是否为空（之前为request数据之前判断，不便于改变submitted状态）
# 增加：在线预览特性