### PR TITLE
新增进度被评论的消息提醒

### DIFF
--- a/src/components/common/header/inform/index.jsx
+++ b/src/components/common/header/inform/index.jsx
@@ -10,13 +10,16 @@ import MessageService from "service/message";
 import { Store } from "store";
 import "./index.scss";
 
-const kind = ["文档", "文件"];
+const kind = ["文档", "文件", "进度"];
+
 function getPath(sourcekind, projectID, sourceID) {
   switch (sourcekind) {
     case 0:
       return `/project/${projectID}/doc/${sourceID}`;
     case 1:
       return `/project/${projectID}/file/${sourceID}`;
+    case 2:
+      return `/status/${sourceID}`;
     default:
       return `/`;
   }
@@ -153,7 +156,7 @@ class Inform extends Component {
                         <div className="info-item" key={el.time + el.sourceID}>
                           <div className="info-text">
                             {el.fromName}
-                            {el.action}
+                            {el.action + "了你的"}
                             <Link
                               className="info-item-to"
                               to={getPath(

--- a/src/modules/message/index.jsx
+++ b/src/modules/message/index.jsx
@@ -11,7 +11,7 @@ import MessageService from "service/message";
 import "static/css/common.scss";
 import "./index.scss";
 
-const kind = ["文档", "文件"];
+const kind = ["文档", "文件", "进度"];
 
 function getPath(sourcekind, projectID, sourceID) {
   switch (sourcekind) {
@@ -19,6 +19,8 @@ function getPath(sourcekind, projectID, sourceID) {
       return `/project/${projectID}/doc/${sourceID}`;
     case 1:
       return `/project/${projectID}/file/${sourceID}`;
+    case 2:
+      return `/status/${sourceID}`;
     default:
       return `/`;
   }
@@ -89,7 +91,7 @@ class Message extends Component {
               <div className="message-item" key={el.sourceID}>
                 <div className="message-text">
                   {el.fromName}
-                  {el.action}
+                  {el.action + "了你的"}
                   <Link
                     className="info-item-to"
                     to={`${getPath(el.sourceKind, el.projectID, el.sourceID)}`}


### PR DESCRIPTION
- sry学长新加了sourceKind=2的进度被评论的消息提醒，经过测试可以正确接收到消息，并跳转正确。
- 经测试，发现当文件或文档被关注时，文件被评论，文档被编辑，会产生新的消息提醒，正确接受并且路由跳转正确
- 修改消息内容：“苏亚鹏评论进度” -> “苏亚鹏评论了你的进度”